### PR TITLE
Ignore empty result errors

### DIFF
--- a/lib/ts3admin.class.php
+++ b/lib/ts3admin.class.php
@@ -4784,7 +4784,11 @@ class ts3admin {
 			if($tracert != null)
 				$this->addDebugLog('ErrorID: '.$cutIdAndMsg[0].' | Message: '.$this->unEscapeText($cutIdAndMsg[1]), $tracert[1]['function'], $tracert[0]['line']);
 			
-			return $this->generateOutput(false, array('ErrorID: '.$cutIdAndMsg[0].' | Message: '.$this->unEscapeText($cutIdAndMsg[1])), false);
+			if($cutIdAndMsg[0] == 1281){ // if "database empty result set"
+				return $this->generateOutput(true, array(), '');
+			}else{
+				return $this->generateOutput(false, array('ErrorID: '.$cutIdAndMsg[0].' | Message: '.$this->unEscapeText($cutIdAndMsg[1])), false);
+			}
 		}else{
 			return $this->generateOutput(true, array(), $data);
 		}


### PR DESCRIPTION
The query uses `error id=1281 msg=database\sempty\sresult\sset` to signal that there are no results to return - which makes sens for a text-based protocol. In PHP however, we have the option to simply return an actual empty value.

Some of the commands that may return an empty result error:
- channelclientpermlist
- channelgroupclientlist
- clientdbfind
- clientpermlist
- complainlist
- ftgetfilelist
- ftlist
- messagelist
- privilegekeylist
- servergroupclientlist
- servergrouppermlist
- servertemppasswordlist
- tokenlist

So, ignoring the empty result error and returning an empty value would would benefit users, as they no longer have to check for this error themself whenever they use any of the commands listed above.